### PR TITLE
Normalize the musical note names for slovak

### DIFF
--- a/n/music/_locales/sk/hoc2024-ts-music-n-strings.json
+++ b/n/music/_locales/sk/hoc2024-ts-music-n-strings.json
@@ -14,7 +14,7 @@
   "Instrument_Activity.Bells|block": "zvončeky",
   "Instrument_Activity.Guitar|block": "gitara",
   "Instrument_Activity.Xylophone|block": "xylofón",
-  "Note.Do|block": "robiť",
+  "Note.Do|block": "do",
   "Note.Fa|block": "fa",
   "Note.La|block": "la",
   "Note.Mi|block": "mi",


### PR DESCRIPTION
Make the Slovak note names match `do, fa, la, mi, re, so, ti`.